### PR TITLE
chore: adds conda env vars explicitly

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,8 +17,8 @@ jobs:
         baseImage:
           - python:3.10
           - mcr.microsoft.com/devcontainers/python:3.10
-          # - ubuntu:latest
-          # - mcr.microsoft.com/devcontainers/base:ubuntu
+          - ubuntu:focal
+          - mcr.microsoft.com/devcontainers/base:ubuntu
     steps:
       - uses: actions/checkout@v3
 

--- a/src/renku/devcontainer-feature.json
+++ b/src/renku/devcontainer-feature.json
@@ -31,5 +31,10 @@
         "ghcr.io/rocker-org/devcontainer-features/miniforge",
         "ghcr.io/devcontainers/features/git",
         "ghcr.io/devcontainers/features/git-lfs"
-    ]
+    ],
+    "containerEnv": {
+		"CONDA_DIR": "/opt/conda",
+		"CONDA_SCRIPT": "/opt/conda/etc/profile.d/conda.sh",
+		"PATH": "/opt/conda/bin:${PATH}"
+	}
 }

--- a/src/renku/install.sh
+++ b/src/renku/install.sh
@@ -77,5 +77,5 @@ fi
 
 # install jupyter
 if [ "${INSTALLJUPYTER}" = "true" ]; then
-    /opt/conda/bin/mamba install jupyterlab
+    /opt/conda/bin/mamba install -y jupyterlab
 fi

--- a/test/renku/scenarios.json
+++ b/test/renku/scenarios.json
@@ -1,10 +1,4 @@
 {
-    "renku": {
-        "image": "mcr.microsoft.com/devcontainers/python:3.10",
-        "features": {
-            "renku": {}
-        }
-    },
     "renku-base-notebook": {
         "image": "jupyter/base-notebook:python-3.10",
         "features": {

--- a/test/renku/test.sh
+++ b/test/renku/test.sh
@@ -12,6 +12,8 @@ source dev-container-features-test-lib
 # check <LABEL> <cmd> [args...]
 check "renku is installed" bash -c "renku | grep 'Check common Renku commands'"
 check "git-lfs is installed" bash -c "git lfs | grep 'git lfs <command>'"
+check "conda is available" bash -c "conda --version"
+check "/opt/conda/bin is on PATH" bash -c "grep -q '/opt/conda/bin' <<< '$PATH'"
 
 # Report results
 # If any of the checks above exited with a non-zero exit code, the test will fail.


### PR DESCRIPTION
The container's environment was missing conda in the PATH; this fixes it temporarily. 

See also https://github.com/rocker-org/devcontainer-features/issues/168.