### PR TITLE
chore: notebook --> server hack

### DIFF
--- a/src/renku/devcontainer-feature.json
+++ b/src/renku/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
     "name": "Renku CLI",
     "id": "renku",
-    "version": "1.2.0",
+    "version": "1.3.0",
     "description": "Provides the Renku CLI and supporting packages.",
     "options": {
         "version": {

--- a/src/renku/install.sh
+++ b/src/renku/install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -i
 set -e
- 
+
 USER_ID=1000
 USERNAME=${USERNAME:-${_REMOTE_USER:-"automatic"}}
 
@@ -78,4 +78,5 @@ fi
 # install jupyter
 if [ "${INSTALLJUPYTER}" = "true" ]; then
     /opt/conda/bin/mamba install -y jupyterlab
+    ln -sf /opt/conda/bin/jupyter-server /opt/conda/bin/jupyter-notebook
 fi

--- a/test/renku/renku-base-notebook.sh
+++ b/test/renku/renku-base-notebook.sh
@@ -7,7 +7,11 @@ source dev-container-features-test-lib
 
 # Feature-specific tests
 # The 'check' command comes from the dev-container-features-test-lib.
-check "renku is installed" bash -c "renku | grep 'Check common Renku commands'"
+check "renku is available" bash -c "renku --help"
+check "git-lfs is available" bash -c "git lfs --help"
+check "conda is available" bash -c "conda --version"
+check "/opt/conda/bin is on PATH" bash -c "grep -q '/opt/conda/bin' <<< '$PATH'"
+check "jupyter notebook works" bash -c "jupyter notebook --help"
 
 # check that the user is indeed jovyan
 check "user is jovyan" bash -c "whoami | grep jovyan"

--- a/test/renku/test.sh
+++ b/test/renku/test.sh
@@ -14,6 +14,7 @@ check "renku is installed" bash -c "renku | grep 'Check common Renku commands'"
 check "git-lfs is installed" bash -c "git lfs | grep 'git lfs <command>'"
 check "conda is available" bash -c "conda --version"
 check "/opt/conda/bin is on PATH" bash -c "grep -q '/opt/conda/bin' <<< '$PATH'"
+check "jupyter notebook works" bash -c "jupyter notebook --help"
 
 # Report results
 # If any of the checks above exited with a non-zero exit code, the test will fail.


### PR DESCRIPTION
Renku sessions start with `jupyter notebook` which is missing here. 